### PR TITLE
MF-496 : wrong key error in Translation .en

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -37,7 +37,7 @@
   "revise": "Revise",
   "discontinue": "Discontinue",
   "modify": "Modify",
-  "discontinue": "Reorder",
+  "reorder": "Reorder",
   "noCurrentMedicationsDocumented": "No current medications are documented.",
   "noPastMedicationsDocumented": "No past medications are documented.",
 


### PR DESCRIPTION
ticket : [MF-496](https://issues.openmrs.org/browse/MF-496)
wrong key  mapping from
`discontinue:Reorder`